### PR TITLE
initialize via manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -6,7 +6,7 @@ applications:
   buildpack: java_buildpack
   path: ./target/spring-petclinic-cf-2.1.0.jar
   timeout: 120
-  #env:
+  env:
+    JAVA_OPTS: '-Dspring.datasource.initialization-mode=always'
     #SPRING_PROFILES_ACTIVE: db2
     #JBP_CONFIG_SPRING_AUTO_RECONFIGURATION: '{enabled: false}'
-    #JAVA_OPTS: '-Dspring.datasource.initialization-mode=always'

--- a/manifest.yml
+++ b/manifest.yml
@@ -5,6 +5,8 @@ applications:
   random-route: true
   buildpack: java_buildpack
   path: ./target/spring-petclinic-cf-2.1.0.jar
+  timeout: 120
   #env:
     #SPRING_PROFILES_ACTIVE: db2
     #JBP_CONFIG_SPRING_AUTO_RECONFIGURATION: '{enabled: false}'
+    #JAVA_OPTS: '-Dspring.datasource.initialization-mode=always'

--- a/src/main/resources/application-db2.properties
+++ b/src/main/resources/application-db2.properties
@@ -5,8 +5,9 @@ spring.datasource.username=${vcap.services.petclinic-db.credentials.username}
 spring.datasource.password=${vcap.services.petclinic-db.credentials.password}
 spring.datasource.maxActive=3
 
-
-# Uncomment these to create the database object the first time the app runs
+# Uncomment this to create the database object the first time the app runs
 # For subsequent runs comment these out
-spring.datasource.initialization-mode=always
+# spring.datasource.initialization-mode=always
+
+# Continue if errors are thrown in schema creation
 spring.datasource.continue-on-error=true


### PR DESCRIPTION
move database initialization into an environment variable setting in `manifest.yml` add timeout property to manifest to avoid close-misses in timing of startup of the runtime on busy IBM Cloud regions.